### PR TITLE
fix: align with SDK v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,12 @@ app.post("/start-workflow", async (req: Request, res: Response) => {
       return res.status(400).json({ error: "workflow_id is required" });
     }
 
-    const handle = (await resonate.rpc(
+    const result = await resonate.rpc(
       workflowId,
-      "foo",
+      "foo-workflow",
       workflowId,
       resonate.options({ target: "poll://any@workers" })
-    )) as { result: Promise<any> };
-
-    const result = await handle.result;
+    );
 
     return res.status(200).json({ message: result });
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- Updated README code snippet to match actual `gateway.ts` pattern
- Removed stale `handle.result` pattern (cast + `.result` property)
- README now shows the correct `const result = await resonate.rpc(...)` usage
- Also fixed function name from `"foo"` to `"foo-workflow"` to match source

## Context
Part of the Resonate v0.10.0 alignment sweep (iteration-06).

## Test plan
- [ ] Code review confirms README snippet matches gateway.ts
- [ ] No references to removed APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)