### PR TITLE
Bump @resonatehq/sdk to ^0.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@resonatehq/sdk": "^0.10.0",
+    "@resonatehq/sdk": "^0.11.4",
     "@types/express": "^5.0.3",
     "express": "^5.1.0"
   }


### PR DESCRIPTION
Bumps the direct @resonatehq/sdk dependency from ^0.10.0 to ^0.11.4.

- package.json: `@resonatehq/sdk` constraint changed to `^0.11.4`
- No lockfile is committed in this repo (bun.lock and package-lock.json are gitignored); `bun install` resolves `@resonatehq/sdk@0.11.4`
- Verified with `npx tsc --noEmit`: passed, exit code 0